### PR TITLE
Promote app URLs to project URLs

### DIFF
--- a/registry/urls.py
+++ b/registry/urls.py
@@ -19,7 +19,6 @@ from django.views.generic.base import RedirectView
 
 
 urlpatterns = [
-    path("", RedirectView.as_view(url="/actions/")),
-    path("actions/", include("actions.urls")),
+    path("", include("actions.urls")),
     path("admin/", admin.site.urls),
 ]


### PR DESCRIPTION
Promote the actions app's URLs to the registry project's URLs. This means we don't have to redirect from `/` to `/actions` (a good thing) but might be limiting, if we choose to add another app in the future (a bad thing).