### PR TITLE
Add the URL to the site link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Actions Registry is a simple Django website hosting information about reusable actions
 for the OpenSAFELY framework.
 
-It is deployed at [actions.opensafely.org]().
+It is deployed at [actions.opensafely.org](https://actions.opensafely.org).
 
 
 ## Developer docs


### PR DESCRIPTION
It was missing, so the link just gives a GitHub 404 error