### PR TITLE
Add a Deploy Concurrency Lock

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,6 +104,8 @@ jobs:
 
     if: github.ref == 'refs/heads/main'
 
+    concurrency: deploy-production
+
     steps:
       - uses: actions/checkout@v3
       - uses: extractions/setup-just@aa5d15c144db4585980a44ebfdd2cf337c4f14cb  # v1.4.0


### PR DESCRIPTION
Currently in-flight deploys fail subsequent deploys, this will block subsequent deploys until the first one finishes.