### PR TITLE
Don't pipe to systemd-cat

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,23 +1,23 @@
 {
     "cron": [
         {
-            "command": "python manage.py runjobs hourly |& systemd-cat -t actions-registry",
+            "command": "python manage.py runjobs hourly",
             "schedule": "@hourly"
         },
         {
-            "command": "python manage.py runjobs daily |& systemd-cat -t actions-registry",
+            "command": "python manage.py runjobs daily",
             "schedule": "@daily"
         },
         {
-            "command": "python manage.py runjobs weekly |& systemd-cat -t actions-registry",
+            "command": "python manage.py runjobs weekly",
             "schedule": "@weekly"
         },
         {
-            "command": "python manage.py runjobs monthly |& systemd-cat -t actions-registry",
+            "command": "python manage.py runjobs monthly",
             "schedule": "@monthly"
         },
         {
-            "command": "python manage.py runjobs yearly |& systemd-cat -t actions-registry",
+            "command": "python manage.py runjobs yearly",
             "schedule": "@yearly"
         }
     ]


### PR DESCRIPTION
Dokku passes the commands in app.json to dokku run, meaning they are already logged. Consequently, we don't (think we) need to pipe to systemd-cat.