### PR TITLE
Remove unnecessary black config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,3 @@
-[tool.black]
-exclude = '''
-(
-  /(
-      \.git         # exclude a few common directories
-    | \.direnv
-    | \.venv
-    | venv
-  )/
-)
-'''
-
 [tool.coverage.run]
 branch = true
 omit = [


### PR DESCRIPTION
By default (according to --help as of v22.8.0) black is already ignoring this list of directories:

/(\.direnv|\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|venv|\.svn|_build|buck-out|build|dist|__pypackages__)/

Using --exclude overwrites this list.

Refs: opensafely-core/repo-template#85