### PR TITLE
Fix Dockerfile entrypoints and remove Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: gunicorn actions.wsgi --config=gunicorn.conf.py

--- a/actions/logging.py
+++ b/actions/logging.py
@@ -79,6 +79,6 @@ logging_config_dict = {
             "level": "INFO",
             "propagate": False,
         },
-        "jobserver": {"handlers": ["console"], "level": "INFO", "propagate": False},
+        "actions": {"handlers": ["console"], "level": "INFO", "propagate": False},
     },
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -115,6 +115,7 @@ WORKDIR /app
 # This may not be necessary, but it probably doesn't hurt
 ENV PYTHONPATH=/app
 
+EXPOSE 8000
 
 ##################################################
 #
@@ -139,9 +140,12 @@ COPY --from=node-builder /usr/src/app/assets/dist /app/assets/dist
 # collect static files
 RUN SECRET_KEY=dummy-key python /app/manage.py collectstatic --no-input
 
-# We set command rather than entrypoint, to make it easier to run different
-# things from the cli
-CMD ["/app/docker/entrypoints/prod.sh"]
+# We set a default command rather than entrypoint, to make it easier to run
+# different things from the cli...
+CMD ["gunicorn", "actions.wsgi", "--config=gunicorn.conf.py"]
+
+# But we set the entrypoint to ensure some basic tasks are performed
+ENTRYPOINT ["/app/docker/entrypoints/prod.sh"]
 
 # finally, tag with build information. These will change regularly, therefore
 # we do them as the last action.

--- a/docker/entrypoints/dev.sh
+++ b/docker/entrypoints/dev.sh
@@ -3,10 +3,7 @@
 set -euo pipefail
 
 ./manage.py migrate
-./manage.py ensure_groups
 ./manage.py collectstatic --no-input --clear | grep -v '^Deleting '
-./manage.py ensure_superuser
-INCLUDE_PRIVATE=t ./manage.py populate_reports
 ./manage.py createcachetable
 
 exec "$@"

--- a/docker/entrypoints/prod.sh
+++ b/docker/entrypoints/prod.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
-
 set -euo pipefail
 
 ./manage.py migrate
-./manage.py ensure_groups
 ./manage.py createcachetable
 
-exec gunicorn output_explorer.wsgi --config=gunicorn.conf.py
+exec "$@"


### PR DESCRIPTION
The Procfile did not run migrations, so was broken.

This change properly configures the entrypoints to run migrations and
match our other services.

It also removes some copypasta from other services when the docker
infrastructure was set up.
