### PR TITLE
chore: pin pyyaml to 5.3.1

### DIFF
--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -14,4 +14,5 @@ isort
 pytest
 pytest-cov
 pytest-django
+pyyaml==5.3.1
 responses

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -11,6 +11,7 @@ environs[django]
 furl
 gunicorn
 osgithub
+pyyaml==5.3.1
 requests
 structlog
 whitenoise[brotli]


### PR DESCRIPTION
* 5.4.1 is broken by https://github.com/yaml/pyyaml/issues/724