### PR TITLE
Update ppa domain

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN rm -f /etc/apt/apt.conf.d/docker-clean
 # see: https://gist.github.com/tiran/2dec9e03c6f901814f6d1e8dad09528e
 # use space efficient utility from base image
 RUN --mount=type=cache,target=/var/cache/apt \
-    echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal main" > /etc/apt/sources.list.d/deadsnakes-ppa.list &&\
+    echo "deb https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu focal main" > /etc/apt/sources.list.d/deadsnakes-ppa.list &&\
     /usr/lib/apt/apt-helper download-file 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xf23c5a6cf475977595c89f51ba6932366a755776' /etc/apt/trusted.gpg.d/deadsnakes.asc &&\
     root/docker-apt-install.sh python3.10 python3.10-venv python3.10-distutils tzdata ca-certificates
 


### PR DESCRIPTION
ppa domains changed in 2022; although the old ones were supposed to remain indefinitely, they're currently inaccessible; but we should update to the new one anyway

https://blog.launchpad.net/ppa/new-domain-names-for-ppas