### PR TITLE
Add project metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-${GITHUB_REPOSITORY_NAME}
+OpenSAFELY Actions Registry
 Copyright (C) University of Oxford
 
 This program is free software: you can redistribute it and/or modify

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,14 @@
+[project]
+name = "actions-registry"
+description = "actions-registry"
+readme = "README.md"
+authors = [{name = "OpenSAFELY", email = "tech@opensafely.org"}]
+license = {file = "LICENSE"}
+classifiers = [
+  "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
+]
+requires-python = ">=3.10"
+
 [tool.coverage.run]
 branch = true
 omit = [


### PR DESCRIPTION
We add project metadata to `pyproject.toml` because:

1. This is how the Python community have agreed to store project
   metadata, for packaging as well as for other tools ([PEP 621][]).
2. Ruff looks to `project.requires-python` to determine which Python to
   use; if neither are provided, it defaults to Python 3.9 (#331). This
   project, however, uses Python 3.10. Not having this project metadata
   will, sooner or later, mean that some code will have to be
   reformatted.

[PEP 621]: https://peps.python.org/pep-0621/