### PR TITLE
Replace Plausible JS with script tag

### DIFF
--- a/actions/templates/base.html
+++ b/actions/templates/base.html
@@ -23,6 +23,8 @@
     <link rel="icon" href="{% static 'icon.svg' %}" type="image/svg+xml">
     <link rel="apple-touch-icon" href="{% static 'apple-touch-icon.png' %}">
     <link rel="manifest" href="{% static 'manifest.webmanifest' %}">
+
+    <script defer data-domain="actions.opensafely.org" src="https://plausible.io/js/script.js"></script>
   </head>
   <body class="flex flex-col min-h-screen">
     {% include "partials/header.html" %}

--- a/assets/src/scripts/main.js
+++ b/assets/src/scripts/main.js
@@ -6,14 +6,3 @@ import "@fontsource/public-sans/700.css";
 
 // Styles
 import "../styles/main.css";
-
-// Plausible
-if (document.location.hostname === "actions.opensafely.org") {
-  const script = document.createElement("script");
-  script.defer = true;
-  script.setAttribute("data-domain", "actions.opensafely.org");
-  script.id = "plausible";
-  script.src = "https://plausible.io/js/plausible.compat.js";
-
-  document.head.appendChild(script);
-}


### PR DESCRIPTION
Part of https://github.com/opensafely-core/sysadmin/issues/175

We no longer need to use the `compat` script as Internet Explorer usage has fallen below 1% of traffic.