### PR TITLE
Make furl a transitive dependency

### DIFF
--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -8,7 +8,6 @@ django-extensions
 django-permissions-policy
 django-vite
 environs[django]
-furl
 gunicorn
 osgithub
 pyyaml

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -294,9 +294,7 @@ exceptiongroup==1.2.2 \
 furl==2.1.3 \
     --hash=sha256:5a6188fe2666c484a12159c18be97a1977a71d632ef5bb867ef15f54af39cc4e \
     --hash=sha256:9ab425062c4217f9802508e45feb4a83e54324273ac4b202f1850363309666c0
-    # via
-    #   -r requirements.prod.in
-    #   osgithub
+    # via osgithub
 gunicorn==23.0.0 \
     --hash=sha256:ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d \
     --hash=sha256:f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec


### PR DESCRIPTION
Previously, furl was was listed in `requirements.prod.in`, making it a direct dependency. However, furl isn't used by the project; it's a transitive dependency, and shouldn't be listed in
`requirements.prod.in`.