### PR TITLE
Add diabetes-algo to whitelist

### DIFF
--- a/actions/jobs/daily/fetch_action.py
+++ b/actions/jobs/daily/fetch_action.py
@@ -17,6 +17,7 @@ class Job(DailyJob):
         "opensafely-actions/dataset-report",
         "opensafely-actions/deciles-charts",
         "opensafely-actions/demographic-standardisation",
+        "opensafely-actions/diabetes-algo",
         "opensafely-actions/kaplan-meier-function",
         "opensafely-actions/project-dag",
         "opensafely-actions/safetab",


### PR DESCRIPTION
We don't fetch all the repos from the opensafely-actions org, because some aren't reusable actions (.github) and some are for testing (minimal-action). Instead, we have a whitelist. We recently transferred in diabetes-algo (opensafely-actions/.github#8), so we should add it to the whitelist.