### PR TITLE
Add template tag to correctly resolve relative Github links

### DIFF
--- a/actions/templates/actions/version.html
+++ b/actions/templates/actions/version.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load static %}
+{% load resolve_links %}
 
 {% block meta %}
 <title>OpenSAFELY: Actions Registry - {{ action.repo_name }}</title>
@@ -80,7 +81,7 @@
         prose-code:bg-oxford-50 prose-code:m-0 prose-code:font-normal prose-code:rounded-sm prose-code:text-sm prose-code:px-1 prose-code:py-1 prose-code:before:content-none prose-code:after:content-none
       "
       >
-        {{ version.readme|safe }}
+        {{ version.readme|resolve_relative_links:version|safe }}
       </div>
     </div>
   </div>

--- a/actions/templatetags/resolve_links.py
+++ b/actions/templatetags/resolve_links.py
@@ -1,0 +1,24 @@
+import re
+from urllib.parse import urljoin
+
+from django import template
+
+
+register = template.Library()
+
+
+@register.filter
+def resolve_relative_links(readme, version):
+    base_url = urljoin(
+        version.action.get_github_url(),
+        f"blob/{version.tag}/",
+    )
+
+    # Resolve relative links in link tags
+    link_tag_pattern = r'(<a href=")((?!.*?(http|\.com|\.uk|\.net)).*?")'
+    readme = re.sub(link_tag_pattern, rf"\1{base_url}\2", readme)
+
+    # Resolve relative links in img tags (raw=true is needed to display images)
+    img_tag_pattern = r'(<img src=")((?!.*?(http|\.com|\.uk|\.net)).*?)"'
+    readme = re.sub(img_tag_pattern, rf'\1{base_url}\2?raw=true"', readme)
+    return readme

--- a/tests/actions/test_templatetags.py
+++ b/tests/actions/test_templatetags.py
@@ -1,0 +1,55 @@
+from datetime import datetime, timezone
+
+import pytest
+
+import actions.templatetags.resolve_links as resolve_links
+from actions.models import Action
+
+
+@pytest.fixture
+def version():
+    action = Action.objects.create(
+        org="opensafely-actions",
+        repo_name="test-action",
+    )
+    return action.versions.create(
+        tag="v1.0",
+        committed_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+def test_resolve_relative_links_with_text_links(version):
+    html = (
+        'Here is link 1\n<a href="link_1.md">Link 1</a>\n'
+        'Here is link 2\n<a href="https://site.com">Link 2</a>'
+    )
+    readme = resolve_links.resolve_relative_links(html, version)
+
+    assert readme == (
+        "Here is link 1\n"
+        '<a href="https://github.com/opensafely-actions/test-action/blob/v1.0/link_1.md">Link 1</a>\n'
+        "Here is link 2\n"
+        '<a href="https://site.com">Link 2</a>'
+    )
+
+
+def test_resolve_relative_links_with_image_links(version):
+    html = (
+        "Here is image 1\n"
+        '<a href="image_1.png">'
+        '<img src="image_1.png" alt="Image 1"></a>\n'
+        "Here is image 2\n"
+        '<a href="https://site.com/image_2.png">'
+        '<img src="https://site.com/image_2.png" alt="Image 2"></a>'
+    )
+    readme = resolve_links.resolve_relative_links(html, version)
+
+    assert readme == (
+        "Here is image 1\n"
+        '<a href="https://github.com/opensafely-actions/test-action/blob/v1.0/image_1.png">'
+        '<img src="https://github.com/opensafely-actions/test-action/blob/v1.0/image_1.png?raw=true" '
+        'alt="Image 1"></a>\n'
+        "Here is image 2\n"
+        '<a href="https://site.com/image_2.png">'
+        '<img src="https://site.com/image_2.png" alt="Image 2"></a>'
+    )


### PR DESCRIPTION
Closes #54 

- We get the readme for an action version as html from Github, and show this in version.html.

- The readme might link to files in the repo (e.g. images / markdown files). These are relative links that github does not resolve to absolute links before passing us the readme html. As a result the links are broken on our site.

- Use a template tag (herenamed `resolve_relative_links` to convert relative github links to absolute ones.

- `<a>` tags and `<img>` tags are treated separately - the `src` attribute of the `<img>` tag requires raw image urls, while we do not want to pass raw file urls for links that users would click.

- Note that the version tag is used in the url templates to ensure that the links match the readme text being shown.