### PR TITLE
Replace Dbot with Bbot for Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,6 @@
 version: 2
 
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/.github/workflows/update_python_dependencies.yml
+++ b/.github/workflows/update_python_dependencies.yml
@@ -1,0 +1,28 @@
+name: Update Python dependencies
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 23 * * 0"
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  update-python-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: "opensafely-core/setup-action@v1"
+        with:
+          python-version: "3.10"
+          install-just: true
+      - uses: actions/create-github-app-token@v1
+        id: generate-token
+        with:
+          app-id: 1031449
+          private-key: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
+      - uses: bennettoxford/update-dependencies-action@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          update_command: "just update-dependencies"

--- a/justfile
+++ b/justfile
@@ -107,6 +107,10 @@ upgrade env package="": virtualenv
     FORCE=true {{ just_executable() }} requirements-{{ env }} $opts
 
 
+# update (upgrade) prod and dev dependencies
+update-dependencies: (upgrade 'prod') (upgrade 'dev')
+
+
 # *ARGS is variadic, 0 or more. This allows us to do `just test -k match`, for example.
 # Run the tests
 test *ARGS: devenv


### PR DESCRIPTION
This replaces Dependabot with Beckybot for Python dependencies. As per [the (draft) dependency updates policy][1], Beckybot runs weekly. Unlike Dependabot, Beckybot will open one PR with one commit that contains the updated dev and prod Python dependencies.

This doesn't replace Dependabot with Beckybot for JS or GH Actions dependencies, as we're happy with Dependabot in these cases.[^1]

Closes #393 

[1]: https://docs.google.com/document/d/1s1zQ_312d7Fy89j5H8AHJSCeLK-rLBBls3XIQJGP9fw/edit?tab=t.0#heading=h.nmecvlmclkww

[^1]: https://bennettoxford.slack.com/archives/C63UXGB8E/p1741363549125569