### PR TITLE
Resolve relative github urls to absolute ones

### DIFF
--- a/actions/templates/actions/version.html
+++ b/actions/templates/actions/version.html
@@ -80,7 +80,7 @@
         prose-code:bg-oxford-50 prose-code:m-0 prose-code:font-normal prose-code:rounded-sm prose-code:text-sm prose-code:px-1 prose-code:py-1 prose-code:before:content-none prose-code:after:content-none
       "
       >
-        {{ version.readme|safe }}
+        {{ readme|safe }}
       </div>
     </div>
   </div>

--- a/actions/utils.py
+++ b/actions/utils.py
@@ -1,0 +1,12 @@
+from urllib.parse import urljoin, urlparse
+
+from bs4 import BeautifulSoup
+
+
+def resolve_relative_urls_to_absolute(html, base_url, tag, attribute):
+    soup = BeautifulSoup(html, "html.parser")
+    for element in soup.find_all(tag):
+        url = element.get(attribute)
+        if url and not urlparse(url).netloc:  # is relative
+            element[attribute] = urljoin(base_url, url)
+    return str(soup)

--- a/actions/views.py
+++ b/actions/views.py
@@ -1,4 +1,8 @@
+from urllib.parse import urljoin
+
 from django.shortcuts import get_object_or_404, redirect, render
+
+from actions.utils import resolve_relative_urls_to_absolute
 
 from .models import Action
 
@@ -18,11 +22,26 @@ def version(request, repo_name, tag):
     action = get_object_or_404(Action, repo_name=repo_name)
     version = get_object_or_404(action.versions, tag=tag)
 
+    readme = resolve_relative_urls_to_absolute(
+        version.readme,
+        urljoin(action.get_github_url(), f"blob/{version.tag}/"),
+        "a",
+        "href",
+    )
+
+    readme = resolve_relative_urls_to_absolute(
+        readme,
+        urljoin(action.get_github_url(), f"raw/{version.tag}/"),
+        "img",
+        "src",
+    )
+
     return render(
         request,
         "actions/version.html",
         {
             "action": action,
             "version": version,
+            "readme": readme,
         },
     )

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -2,6 +2,7 @@
 
 # To generate requirements file, run:
 # pip-compile --generate-hashes --output-file=requirements.prod.txt requirements.prod.in
+bs4
 django
 django-csp
 django-extensions

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -16,6 +16,10 @@ attrs==25.1.0 \
     # via
     #   cattrs
     #   requests-cache
+beautifulsoup4==4.13.3 \
+    --hash=sha256:1bd32405dacc920b42b83ba01644747ed77456a65760e285fbc47633ceddaf8b \
+    --hash=sha256:99045d7d3f08f91f0d656bc9b7efbae189426cd913d830294a15eefa0ea4df16
+    # via bs4
 brotli==1.1.0 \
     --hash=sha256:03d20af184290887bdea3f0f78c4f737d126c74dc2f3ccadf07e54ceca3bf208 \
     --hash=sha256:0541e747cce78e24ea12d69176f6a7ddb690e62c425e01d31cc065e69ce55b48 \
@@ -143,6 +147,10 @@ brotli==1.1.0 \
     --hash=sha256:fd5f17ff8f14003595ab414e45fce13d073e0762394f957182e69035c9f3d7c2 \
     --hash=sha256:fdc3ff3bfccdc6b9cc7c342c03aa2400683f0cb891d46e94b64a197910dc4064
     # via whitenoise
+bs4==0.0.2 \
+    --hash=sha256:a48685c58f50fe127722417bae83fe6badf500d54b55f7e39ffe43b798653925 \
+    --hash=sha256:abf8742c0805ef7f662dce4b51cca104cffe52b835238afc169142ab9b3fbccc
+    # via -r requirements.prod.in
 cattrs==24.1.2 \
     --hash=sha256:67c7495b760168d931a10233f979b28dc04daf853b30752246f4f8471c6d68d0 \
     --hash=sha256:8028cfe1ff5382df59dd36474a86e02d817b06eaf8af84555441bac915d2ef85
@@ -402,6 +410,10 @@ six==1.17.0 \
     #   furl
     #   orderedmultidict
     #   url-normalize
+soupsieve==2.6 \
+    --hash=sha256:e2e68417777af359ec65daac1057404a3c8a5455bb8abc36f1a9866ab1a51abb \
+    --hash=sha256:e72c4ff06e4fb6e4b5a9f0f55fe6e81514581fca1515028625d0f299c602ccc9
+    # via beautifulsoup4
 sqlparse==0.5.3 \
     --hash=sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272 \
     --hash=sha256:cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca
@@ -415,6 +427,7 @@ typing-extensions==4.12.2 \
     --hash=sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8
     # via
     #   asgiref
+    #   beautifulsoup4
     #   cattrs
     #   dj-database-url
     #   environs

--- a/tests/actions/test_utils.py
+++ b/tests/actions/test_utils.py
@@ -1,0 +1,27 @@
+import pytest
+
+from actions import utils
+
+
+@pytest.mark.parametrize(
+    "url,base_url,abs_url",
+    [
+        ("image.jpg", "https://example.com", "https://example.com/image.jpg"),
+        ("./image.jpg", "https://example.com", "https://example.com/image.jpg"),
+        ("../image.jpg", "https://example.com", "https://example.com/image.jpg"),
+        (
+            "https://example.com/image.jpg",
+            "https://example.com",
+            "https://example.com/image.jpg",
+        ),
+    ],
+)
+def test_resolve_relative_urls_to_absolute(url, base_url, abs_url):
+    html = f'<img src="{url}"/>'
+
+    resolved_html = utils.resolve_relative_urls_to_absolute(
+        html, base_url, "img", "src"
+    )
+
+    expected_html = f'<img src="{abs_url}"/>'
+    assert resolved_html == expected_html


### PR DESCRIPTION
Alternative to #402, and addresses the comments made there.
Fixes #54.

- Add a utils function to resolve relative urls to absolute ones. This function is then used in the `version` view to resolve relative github urls in `<a>` and `<img>` tags. This fixes links that are currently broken on the site.

- Beautiful Soup, an html parsing library, is added as a prod dependency.

### Notes
- 8e389f84a1f94254ecc67530be8e74b7f814aaba and 73ebda08dabce89fa5e4a0d30b44e8c6416cedb2 are separate commits only to make reviewing easier. The intention is to squash them into one commit post-approval.



