### PR TITLE
Add a blurb to the homepage

### DIFF
--- a/actions/templates/actions/index.html
+++ b/actions/templates/actions/index.html
@@ -9,6 +9,27 @@
   <div class="flex flex-col">
     <div class="overflow-x-auto -mx-6 lg:-mx-8">
       <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
+        <div class="shadow-sm overflow-hidden border-b border-gray-200 sm:rounded-lg bg-white">
+          <div class="
+            min-w-full px-6 py-8 sm:px-6
+            prose prose-sm sm:prose prose-oxford sm:prose-oxford
+            prose-headings:flex prose-headings:items-center proseauto-headings:text-gray-800
+            prose-a:font-semibold prose-a:hover:text-oxford-800 prose-a:hover:no-underline
+          ">
+            <h1>OpenSAFELY Actions</h1>
+            <p>
+              This website lists all the reusable actions available for use on
+              <a href="https://www.opensafely.org/">OpenSAFELY</a>. 
+              Reusable actions are logical units of analytic code that can be used across multiple studies. 
+            </p>
+            <p>
+              Information for each reusable action is detailed on its individual page. Browse the table to find out
+              more.
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
         <div class="shadow-sm overflow-hidden border-b border-gray-200 sm:rounded-lg">
           <table class="min-w-full divide-y divide-gray-300">
             <thead class="bg-gray-100">

--- a/actions/templates/actions/index.html
+++ b/actions/templates/actions/index.html
@@ -35,7 +35,7 @@
             <thead class="bg-gray-100">
               <tr>
                 <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-600 uppercase tracking-wider">
-                  Actions
+                  Action
                 </th>
                 <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-600 uppercase tracking-wider">
                   Author


### PR DESCRIPTION
Closes #26.

Details on what has been implemented are given in the commit messages.

Any feedback is appreciated. It would be particularly great to have feedback on:
- Whether the approach of putting the blurb directly in the homepage template is appropriate practice
- Whether it is preferable for the blurb and the table to have separate borders (i.e. whether 7f7e5f0485b1f748c0b53695cd4ef8846f883510 should be kept or dropped)