### PR TITLE
Refactor the relative-to-absolute function

### DIFF
--- a/actions/utils.py
+++ b/actions/utils.py
@@ -9,7 +9,7 @@ def resolve_urls(html, base_urls, attributes):
     def resolve(base_url, attribute):
         for element in soup.find_all(lambda element: element.has_attr(attribute)):
             url = element.get(attribute)
-            if url and not urlparse(url).netloc:  # is relative
+            if not urlparse(url).netloc:  # is relative
                 element[attribute] = urljoin(base_url, url)
 
     for base_url, attribute in zip(base_urls, attributes):

--- a/actions/utils.py
+++ b/actions/utils.py
@@ -3,9 +3,9 @@ from urllib.parse import urljoin, urlparse
 from bs4 import BeautifulSoup
 
 
-def resolve_relative_urls_to_absolute(html, base_url, tag, attribute):
+def resolve_relative_urls_to_absolute(html, base_url, attribute):
     soup = BeautifulSoup(html, "html.parser")
-    for element in soup.find_all(tag):
+    for element in soup.find_all(lambda element: element.has_attr(attribute)):
         url = element.get(attribute)
         if url and not urlparse(url).netloc:  # is relative
             element[attribute] = urljoin(base_url, url)

--- a/actions/utils.py
+++ b/actions/utils.py
@@ -3,7 +3,7 @@ from urllib.parse import urljoin, urlparse
 from bs4 import BeautifulSoup
 
 
-def resolve_relative_urls_to_absolute(html, base_urls, attributes):
+def resolve_urls(html, base_urls, attributes):
     soup = BeautifulSoup(html, "html.parser")
 
     def resolve(base_url, attribute):

--- a/actions/utils.py
+++ b/actions/utils.py
@@ -3,15 +3,16 @@ from urllib.parse import urljoin, urlparse
 from bs4 import BeautifulSoup
 
 
-def resolve_relative_urls_to_absolute(html, base_url, attribute):
+def resolve_relative_urls_to_absolute(html, base_urls, attributes):
     soup = BeautifulSoup(html, "html.parser")
 
-    def resolve():
+    def resolve(base_url, attribute):
         for element in soup.find_all(lambda element: element.has_attr(attribute)):
             url = element.get(attribute)
             if url and not urlparse(url).netloc:  # is relative
                 element[attribute] = urljoin(base_url, url)
 
-    resolve()
+    for base_url, attribute in zip(base_urls, attributes):
+        resolve(base_url, attribute)
 
     return str(soup)

--- a/actions/utils.py
+++ b/actions/utils.py
@@ -5,8 +5,13 @@ from bs4 import BeautifulSoup
 
 def resolve_relative_urls_to_absolute(html, base_url, attribute):
     soup = BeautifulSoup(html, "html.parser")
-    for element in soup.find_all(lambda element: element.has_attr(attribute)):
-        url = element.get(attribute)
-        if url and not urlparse(url).netloc:  # is relative
-            element[attribute] = urljoin(base_url, url)
+
+    def resolve():
+        for element in soup.find_all(lambda element: element.has_attr(attribute)):
+            url = element.get(attribute)
+            if url and not urlparse(url).netloc:  # is relative
+                element[attribute] = urljoin(base_url, url)
+
+    resolve()
+
     return str(soup)

--- a/actions/views.py
+++ b/actions/views.py
@@ -24,14 +24,14 @@ def version(request, repo_name, tag):
 
     readme = resolve_relative_urls_to_absolute(
         version.readme,
-        urljoin(action.get_github_url(), f"blob/{version.tag}/"),
-        "href",
+        [urljoin(action.get_github_url(), f"blob/{version.tag}/")],
+        ["href"],
     )
 
     readme = resolve_relative_urls_to_absolute(
         readme,
-        urljoin(action.get_github_url(), f"raw/{version.tag}/"),
-        "src",
+        [urljoin(action.get_github_url(), f"raw/{version.tag}/")],
+        ["src"],
     )
 
     return render(

--- a/actions/views.py
+++ b/actions/views.py
@@ -22,16 +22,12 @@ def version(request, repo_name, tag):
     action = get_object_or_404(Action, repo_name=repo_name)
     version = get_object_or_404(action.versions, tag=tag)
 
+    href_base = urljoin(action.get_github_url(), f"blob/{version.tag}/")
+    src_base = urljoin(action.get_github_url(), f"raw/{version.tag}/")
     readme = resolve_relative_urls_to_absolute(
         version.readme,
-        [urljoin(action.get_github_url(), f"blob/{version.tag}/")],
-        ["href"],
-    )
-
-    readme = resolve_relative_urls_to_absolute(
-        readme,
-        [urljoin(action.get_github_url(), f"raw/{version.tag}/")],
-        ["src"],
+        [href_base, src_base],
+        ["href", "src"],
     )
 
     return render(

--- a/actions/views.py
+++ b/actions/views.py
@@ -2,7 +2,7 @@ from urllib.parse import urljoin
 
 from django.shortcuts import get_object_or_404, redirect, render
 
-from actions.utils import resolve_relative_urls_to_absolute
+from actions import utils
 
 from .models import Action
 
@@ -24,11 +24,7 @@ def version(request, repo_name, tag):
 
     href_base = urljoin(action.get_github_url(), f"blob/{version.tag}/")
     src_base = urljoin(action.get_github_url(), f"raw/{version.tag}/")
-    readme = resolve_relative_urls_to_absolute(
-        version.readme,
-        [href_base, src_base],
-        ["href", "src"],
-    )
+    readme = utils.resolve_urls(version.readme, [href_base, src_base], ["href", "src"])
 
     return render(
         request,

--- a/actions/views.py
+++ b/actions/views.py
@@ -25,14 +25,12 @@ def version(request, repo_name, tag):
     readme = resolve_relative_urls_to_absolute(
         version.readme,
         urljoin(action.get_github_url(), f"blob/{version.tag}/"),
-        "a",
         "href",
     )
 
     readme = resolve_relative_urls_to_absolute(
         readme,
         urljoin(action.get_github_url(), f"raw/{version.tag}/"),
-        "img",
         "src",
     )
 

--- a/tests/actions/test_utils.py
+++ b/tests/actions/test_utils.py
@@ -19,9 +19,7 @@ from actions import utils
 def test_resolve_relative_urls_to_absolute(url, base_url, abs_url):
     html = f'<img src="{url}"/>'
 
-    resolved_html = utils.resolve_relative_urls_to_absolute(
-        html, base_url, "img", "src"
-    )
+    resolved_html = utils.resolve_relative_urls_to_absolute(html, base_url, "src")
 
     expected_html = f'<img src="{abs_url}"/>'
     assert resolved_html == expected_html

--- a/tests/actions/test_utils.py
+++ b/tests/actions/test_utils.py
@@ -16,10 +16,10 @@ from actions import utils
         ),
     ],
 )
-def test_resolve_relative_urls_to_absolute(url, base_url, abs_url):
+def test_resolve_urls(url, base_url, abs_url):
     html = f'<img src="{url}"/>'
 
-    resolved_html = utils.resolve_relative_urls_to_absolute(html, [base_url], ["src"])
+    resolved_html = utils.resolve_urls(html, [base_url], ["src"])
 
     expected_html = f'<img src="{abs_url}"/>'
     assert resolved_html == expected_html

--- a/tests/actions/test_utils.py
+++ b/tests/actions/test_utils.py
@@ -18,9 +18,5 @@ from actions import utils
     ],
 )
 def test_resolve_urls(url, base_url, abs_url):
-    html = f'<img src="{url}"/>'
-
-    resolved_html = utils.resolve_urls(html, [base_url], ["src"])
-
-    expected_html = f'<img src="{abs_url}"/>'
-    assert resolved_html == expected_html
+    resolved_html = utils.resolve_urls(f'<img src="{url}"/>', [base_url], ["src"])
+    assert resolved_html == f'<img src="{abs_url}"/>'

--- a/tests/actions/test_utils.py
+++ b/tests/actions/test_utils.py
@@ -6,6 +6,7 @@ from actions import utils
 @pytest.mark.parametrize(
     "url,base_url,abs_url",
     [
+        ("", "https://example.com", "https://example.com"),
         ("image.jpg", "https://example.com", "https://example.com/image.jpg"),
         ("./image.jpg", "https://example.com", "https://example.com/image.jpg"),
         ("../image.jpg", "https://example.com", "https://example.com/image.jpg"),

--- a/tests/actions/test_utils.py
+++ b/tests/actions/test_utils.py
@@ -19,7 +19,7 @@ from actions import utils
 def test_resolve_relative_urls_to_absolute(url, base_url, abs_url):
     html = f'<img src="{url}"/>'
 
-    resolved_html = utils.resolve_relative_urls_to_absolute(html, base_url, "src")
+    resolved_html = utils.resolve_relative_urls_to_absolute(html, [base_url], ["src"])
 
     expected_html = f'<img src="{abs_url}"/>'
     assert resolved_html == expected_html


### PR DESCRIPTION
I'm stretching the definition of "refactor" here, because I've also changed the function's API. The aim is to simplify the function's signature and to avoid instantiating the `BeautifulSoup` class more than we have to.