### PR TITLE
Remove the "Tag" section

### DIFF
--- a/actions/templates/actions/version.html
+++ b/actions/templates/actions/version.html
@@ -25,16 +25,6 @@
         </div>
         <div class="sm:col-span-2">
           <dt class="text-sm font-semibold text-gray-600">
-            Tag
-          </dt>
-          <dd class="mt-1 text-sm text-gray-900">
-            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium uppercase bg-oxford-100 text-oxford-600">
-              {{ version.tag }}
-            </span>
-          </dd>
-        </div>
-        <div class="sm:col-span-2">
-          <dt class="text-sm font-semibold text-gray-600">
             All versions
           </dt>
           {% for action_version in action.versions.all %}


### PR DESCRIPTION
The "Tag" section is redundant and poorly named. We now have an "All versions" section that highlights the latest version, and refers to it as a *version* rather than as a *tag*.