### PR TITLE
Remove "Author" column

### DIFF
--- a/actions/templates/actions/index.html
+++ b/actions/templates/actions/index.html
@@ -38,9 +38,6 @@
                   Action
                 </th>
                 <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-600 uppercase tracking-wider">
-                  Author
-                </th>
-                <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-600 uppercase tracking-wider">
                   Latest version
                 </th>
                 <th class="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-600 uppercase tracking-wider">
@@ -55,9 +52,6 @@
                   <a href="{{ action.get_absolute_url }}" class="text-oxford-800 hover:text-oxford-600 truncate max-w-sm md:max-w-none">
                     {{ action.repo_name }}
                   </a>
-                </td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                  {{ action.org }}
                 </td>
                 <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                   <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium uppercase bg-oxford-100 text-oxford-600">


### PR DESCRIPTION
This removes the "Author" column from the homepage. The values in this column were the GH organisations to which the GH repositories belonged: In practice, always "opensafely-actions". The values in this column weren't the authors of the reusable actions.

![OpenSAFELY Actions Registry](https://github.com/user-attachments/assets/11a7f56b-79a7-4a65-9b6e-2a47bceee44d)

Closes #25