### PR TITLE
Set `.anchor` elements to `display: none;`

### DIFF
--- a/assets/src/styles/main.css
+++ b/assets/src/styles/main.css
@@ -41,25 +41,7 @@
 
 @layer utilities {
   .anchor {
-    margin-left: -20px;
-    padding-right: 4px;
-  }
-
-  .octicon-link {
-    @apply align-middle invisible;
-  }
-
-  .octicon-link path {
-    @apply fill-oxford-600;
-  }
-
-  h1:hover .anchor .octicon-link,
-  h2:hover .anchor .octicon-link,
-  h3:hover .anchor .octicon-link,
-  h4:hover .anchor .octicon-link,
-  h5:hover .anchor .octicon-link,
-  h6:hover .anchor .octicon-link {
-    @apply visible;
+    display: none;
   }
 
   .prose-oxford {


### PR DESCRIPTION
Closes #417.

- The `.anchor` elements in our displayed readmes (including its children svg elements) lead to large spaces under headings. The link is hidden somehwere within this large gap, and upon clicking sends the user to the readme on github. This looks awkward and is unhelpful.

- We set these `.anchor` elements to `display: none;`, so that they are removed from the page and no longer leave a large white gap under the headings.

- We also remove the styling that applies to the now removed elements, since they no longer have an effect on the page.