### PR TITLE
Pin Django Debug Toolbar to v5.2

### DIFF
--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -4,7 +4,9 @@
 # To generate a requirements file that includes both prod and dev requirements, run:
 # pip-compile --generate-hashes --output-file=requirements.dev.txt requirements.dev.in
 
-django-debug-toolbar
+# Pin until https://github.com/opensafely-core/actions-registry/issues/481 is resolved.
+django-debug-toolbar~=5.2
+
 pip-tools
 pre-commit
 pytest


### PR DESCRIPTION
We currently can't upgrade due to a failing test (#481).

This might be a little tricky to fix, because the test involves some slightly complicated behaviour of Django's settings.

Let's pin this for now, since it's only a dev dependency, and fix it later.