### PR TITLE
Pin pip to version 25.2

### DIFF
--- a/justfile
+++ b/justfile
@@ -28,8 +28,8 @@ virtualenv:
     # allow users to specify python version in .env
     PYTHON_VERSION=${PYTHON_VERSION:-$DEFAULT_PYTHON}
 
-    # create venv and upgrade pip
-    test -d $VIRTUAL_ENV || { $PYTHON_VERSION -m venv $VIRTUAL_ENV && $PIP install --upgrade pip; }
+    # create venv and install latest pip compatible with pip-tools
+    test -d $VIRTUAL_ENV || { $PYTHON_VERSION -m venv $VIRTUAL_ENV && $PIP install pip==25.2; }
 
     # ensure we have pip-tools so we can run pip-compile
     test -e $BIN/pip-compile || $PIP install pip-tools

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -13,3 +13,7 @@ pytest-django
 pyyaml
 responses
 ruff
+
+# Pin pip due to incompatibility of later releases with pip-tools
+# https://github.com/jazzband/pip-tools/issues/2252
+pip==25.2


### PR DESCRIPTION
The latest version of pip (v25.3) is incompatible with the current version of pip-tools.

See https://github.com/jazzband/pip-tools/issues/2252 for info.