### PR TITLE
Replace deprecated `structlog.threadlocal.wrap_dict`

### DIFF
--- a/actions/logging.py
+++ b/actions/logging.py
@@ -33,6 +33,7 @@ pre_chain = [
 
 structlog.configure(
     processors=[
+        structlog.contextvars.merge_contextvars,
         structlog.stdlib.filter_by_level,
         timestamper,
         structlog.stdlib.add_logger_name,
@@ -44,7 +45,6 @@ structlog.configure(
         structlog.processors.ExceptionPrettyPrinter(),
         structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
     ],
-    context_class=structlog.threadlocal.wrap_dict(dict),
     logger_factory=structlog.stdlib.LoggerFactory(),
     wrapper_class=structlog.stdlib.BoundLogger,
 )


### PR DESCRIPTION
Replace deprecated `structlog.threadlocal.wrap_dict` context storage with `structlog.contextvars.merge_contextvars`, which is the supported context propagation mechanism for latest structlog versions.